### PR TITLE
Skip Id serialization for Notification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/vitiral/jrpc"
 version = "0.4.0"
 
 [dependencies]
-serde = "1.0.40"
-serde_derive = "1.0.40"
+serde = "1.0.101"
+serde_derive = "1.0.101"
 std_prelude = "0.2.12"
-serde_json = "1.0.15"
+serde_json = "1.0.41"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,6 +414,9 @@ impl<M: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned> Request<M
     }
 }
 
+// As reported in the specification, a Notification is a Request object without
+// an "id" member, so we use this function in serde field attribute 
+// #[serde(skip_serializing_if = "path")] to identify a Notification.
 fn id_req_is_notification(id: &IdReq) -> bool {
   match id {
     IdReq::Notification => true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,7 @@ pub struct Request<M, T> {
 
     /// The `id`. See [`Id`](enum.Id.html)
     #[serde(default = "notification")]
+    #[serde(skip_serializing_if = "id_req_is_notification")]
     pub id: IdReq,
 }
 
@@ -411,6 +412,13 @@ impl<M: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned> Request<M
             id: id.into(),
         }
     }
+}
+
+fn id_req_is_notification(id: &IdReq) -> bool {
+  match id {
+    IdReq::Notification => true,
+    _ => false,
+  }
 }
 
 /// Parse a json string, returning either:

--- a/tests/test_notification.rs
+++ b/tests/test_notification.rs
@@ -1,0 +1,45 @@
+extern crate jrpc;
+extern crate serde_json;
+
+use jrpc::*;
+
+#[test]
+fn test_notification_id() {
+    let value: Vec<u32> = vec![1, 2, 3];
+    let request = Request::with_params(
+        IdReq::Notification,
+        "CreateFoo".to_string(),
+        Some(value.clone()),
+    );
+    let json = r#"
+    {
+      "jsonrpc":"2.0",
+      "method":"CreateFoo",
+      "params":[1,2,3]
+    }
+    "#;
+    let json = json.replace("\n", "").replace(" ", "");
+    let result = serde_json::to_string(&request).unwrap();
+    assert_eq!(json, result);
+}
+
+#[test]
+fn test_request_id() {
+    let value: Vec<u32> = vec![1, 2, 3];
+    let request = Request::with_params(
+        Id::from(7),
+        "CreateFoo".to_string(),
+        Some(value.clone()),
+    );
+    let json = r#"
+    {
+      "jsonrpc":"2.0",
+      "method":"CreateFoo",
+      "params":[1,2,3],
+      "id": 7
+    }
+    "#;
+    let json = json.replace("\n", "").replace(" ", "");
+    let result = serde_json::to_string(&request).unwrap();
+    assert_eq!(json, result);
+}


### PR DESCRIPTION
I did what you said in your comment in Issue #3 ;)

I've added two test and the implementation of the `id_req_is_notification` function.

I've also updated all `serde` crates versions in _Cargo.toml_.